### PR TITLE
Compile error in Blob.h when compiling in c++11

### DIFF
--- a/blob/include/blob/Blob.h
+++ b/blob/include/blob/Blob.h
@@ -93,7 +93,7 @@ public:
   const value_type *begin() const { return pointer_; }
   const value_type *end()   const { return pointer_ + size_; }
 
-  bool isCopy() const { return copy_; }
+  bool isCopy() const { return copy_.get(); }
   void setCompressed(bool compressed) { compressed_ = compressed; }
   bool isCompressed() const { return compressed_; }
 

--- a/blob/include/blob/Blob.h
+++ b/blob/include/blob/Blob.h
@@ -93,7 +93,7 @@ public:
   const value_type *begin() const { return pointer_; }
   const value_type *end()   const { return pointer_ + size_; }
 
-  bool isCopy() const { return copy_.get(); }
+  bool isCopy() const { return copy_ != nullptr; }
   void setCompressed(bool compressed) { compressed_ = compressed; }
   bool isCompressed() const { return compressed_; }
 


### PR DESCRIPTION
cannot convert ‘const ConstBufferPtr’ {aka ‘const boost::shared_ptr<const std::vector >’} to ‘bool’
In
bool isCopy() const { return copy_; }